### PR TITLE
Add simple JS webapp

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -1,0 +1,5 @@
+# Sudoku Web App
+
+This folder contains a simple JavaScript implementation of the Sudoku generator so the project can be run in a browser.
+
+Open `index.html` in a web browser and click **Generate Grid** to create a new Sudoku grid.

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Sudoku Generator</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        table { border-collapse: collapse; margin-top: 1em; }
+        td { width: 30px; height: 30px; text-align: center; border: 1px solid #555; }
+        tr:nth-child(3n) td { border-bottom: 2px solid #000; }
+        td:nth-child(3n) { border-right: 2px solid #000; }
+    </style>
+</head>
+<body>
+    <h1>Sudoku Generator</h1>
+    <button id="generate">Generate Grid</button>
+    <table id="grid"></table>
+    <script src="sudoku.js"></script>
+</body>
+</html>

--- a/webapp/sudoku.js
+++ b/webapp/sudoku.js
@@ -1,0 +1,64 @@
+function shuffle(array) {
+    for (let i = array.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+}
+
+function generateSudoku() {
+    const grid = Array.from({ length: 9 }, () => Array(9).fill(0));
+
+    function isValid(row, col, val) {
+        for (let i = 0; i < 9; i++) {
+            if (grid[row][i] === val || grid[i][col] === val) return false;
+        }
+        const startRow = Math.floor(row / 3) * 3;
+        const startCol = Math.floor(col / 3) * 3;
+        for (let r = 0; r < 3; r++) {
+            for (let c = 0; c < 3; c++) {
+                if (grid[startRow + r][startCol + c] === val) return false;
+            }
+        }
+        return true;
+    }
+
+    function fill(r, c) {
+        if (r === 9) return true;
+        const nextR = c === 8 ? r + 1 : r;
+        const nextC = c === 8 ? 0 : c + 1;
+        const nums = shuffle([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        for (const n of nums) {
+            if (isValid(r, c, n)) {
+                grid[r][c] = n;
+                if (fill(nextR, nextC)) return true;
+            }
+        }
+        grid[r][c] = 0;
+        return false;
+    }
+
+    fill(0, 0);
+    return grid;
+}
+
+function render(grid) {
+    const table = document.getElementById('grid');
+    table.innerHTML = '';
+    for (const row of grid) {
+        const tr = document.createElement('tr');
+        for (const val of row) {
+            const td = document.createElement('td');
+            td.textContent = val;
+            tr.appendChild(td);
+        }
+        table.appendChild(tr);
+    }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('generate').addEventListener('click', () => {
+        const grid = generateSudoku();
+        render(grid);
+    });
+});


### PR DESCRIPTION
## Summary
- add a `webapp` folder with a small HTML/JS Sudoku generator
- document how to use the web version in README

## Testing
- `javac` compile tests
- `java -jar junit-platform-console-standalone-1.9.1.jar -cp out/classes:out/test --scan-classpath`

------
https://chatgpt.com/codex/tasks/task_e_68889403bb0c8324848c623f2cef10fc