### PR TITLE
Add Sudoku difficulty levels

### DIFF
--- a/webapp/README.md
+++ b/webapp/README.md
@@ -2,4 +2,4 @@
 
 This folder contains a simple JavaScript implementation of the Sudoku generator so the project can be run in a browser.
 
-Open `index.html` in a web browser and click **Generate Grid** to create a new Sudoku grid.
+Open `index.html` in a web browser to generate puzzles. Choose a difficulty from **Easy**, **Medium**, **Hard**, or **Korean (Expert)** and click **Generate Puzzle**.

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -14,7 +14,14 @@
 </head>
 <body>
     <h1>Sudoku Generator</h1>
-    <button id="generate">Generate Grid</button>
+    <label for="difficulty">Difficulty:</label>
+    <select id="difficulty">
+        <option value="easy">Easy</option>
+        <option value="medium">Medium</option>
+        <option value="hard">Hard</option>
+        <option value="korean">Korean (Expert)</option>
+    </select>
+    <button id="generate">Generate Puzzle</button>
     <table id="grid"></table>
     <script src="sudoku.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add difficulty selector to web UI
- implement Sudoku puzzle generator with four difficulty levels
- show blanks for empty cells
- update README with instructions

## Testing
- `javac -cp /usr/share/java/junit-jupiter-api.jar:/usr/share/java/hamcrest-core.jar:src -d out src/com/company/*.java tests/com/company/*.java`
- `java -jar /usr/share/java/junit-platform-console-standalone.jar -cp out --scan-class-path`

------
https://chatgpt.com/codex/tasks/task_e_688cc34844408324a45349ca1d2f1e14