### PR TITLE
Enhance Sudoku web styling

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -4,13 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Sudoku Generator</title>
-    <style>
-        body { font-family: Arial, sans-serif; }
-        table { border-collapse: collapse; margin-top: 1em; }
-        td { width: 30px; height: 30px; text-align: center; border: 1px solid #555; }
-        tr:nth-child(3n) td { border-bottom: 2px solid #000; }
-        td:nth-child(3n) { border-right: 2px solid #000; }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <h1>Sudoku Generator</h1>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,0 +1,42 @@
+body {
+    font-family: "Helvetica Neue", Arial, sans-serif;
+    background: #f8f8f4;
+    color: #333;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding-top: 2em;
+}
+
+h1 {
+    font-weight: 300;
+    letter-spacing: 2px;
+    margin-bottom: 0.5em;
+}
+
+table {
+    border-collapse: collapse;
+    margin-top: 1em;
+}
+
+td {
+    width: 40px;
+    height: 40px;
+    text-align: center;
+    border: 1px solid #888;
+    font-size: 20px;
+}
+
+tr:nth-child(3n) td {
+    border-bottom: 2px solid #555;
+}
+
+td:nth-child(3n) {
+    border-right: 2px solid #555;
+}
+
+td.given {
+    font-weight: 600;
+    color: #b2985a;
+    background: #f2f0eb;
+}

--- a/webapp/sudoku.js
+++ b/webapp/sudoku.js
@@ -122,7 +122,12 @@ function render(grid) {
         const tr = document.createElement('tr');
         for (const val of row) {
             const td = document.createElement('td');
-            td.textContent = val === 0 ? '' : val;
+            if (val !== 0) {
+                td.textContent = val;
+                td.classList.add('given');
+            } else {
+                td.textContent = '';
+            }
             tr.appendChild(td);
         }
         table.appendChild(tr);


### PR DESCRIPTION
## Summary
- redesign Sudoku web page with elegant minimalist styling
- emphasize generated numbers in the grid
- move CSS rules to a separate stylesheet

## Testing
- `npm test` *(fails: package.json missing)*
- `mvn -q test` *(fails: no POM file found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc74f11c883249ee804601862fcd0