### PR TITLE
Enhance web UI with animations and theme switching

### DIFF
--- a/webapp/index.html
+++ b/webapp/index.html
@@ -5,20 +5,30 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Sudoku Generator</title>
     <link rel="stylesheet" href="styles.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet" />
   </head>
-  <body>
-    <h1>Sudoku Generator</h1>
+  <body data-theme="neon">
+    <button id="theme-toggle" class="theme-toggle" aria-label="Toggle theme">🎨</button>
+    <h1 class="title">Sudoku Generator</h1>
     <div class="difficulty-container">
-      <label for="difficulty">Difficulty:</label>
-      <select id="difficulty" class="select">
-        <option value="easy" class="option">Easy</option>
-        <option value="medium" class="option">Medium</option>
-        <option value="hard" class="option">Hard</option>
-        <option value="korean" class="option">Korean (Expert)</option>
-      </select>
+      <div id="difficulty" class="dropdown" tabindex="0" aria-label="Difficulty selector">
+        <div class="selected">🟢 Easy</div>
+        <ul class="options">
+          <li class="option" data-value="easy">🟢 Easy</li>
+          <li class="option" data-value="medium">🟡 Medium</li>
+          <li class="option" data-value="hard">🔴 Hard</li>
+          <li class="option" data-value="korean">🧠 Korean</li>
+        </ul>
+      </div>
     </div>
-    <button id="generate">Generate Puzzle</button>
+    <button id="generate" class="button">Generate Puzzle</button>
     <table id="grid"></table>
+    <div id="modal" class="modal hidden" role="dialog" aria-modal="true">
+      <div class="modal-content">
+        <p>Warning: May cause existential crisis.</p>
+        <button id="close-modal" class="button">OK</button>
+      </div>
+    </div>
     <script src="sudoku.js"></script>
   </body>
 </html>

--- a/webapp/styles.css
+++ b/webapp/styles.css
@@ -1,76 +1,168 @@
+/* Global theme variables */
+:root {
+  --accent: #00ffe7;
+  --text-color: #f8f8f4;
+  --bg1: #0f2027;
+  --bg2: #203a43;
+  --bg3: #2c5364;
+  --bg4: #1a1a2e;
+}
+
+body[data-theme="retro"] {
+  --accent: #ffdd00;
+  --text-color: #00ff00;
+  --bg1: #000000;
+  --bg2: #000000;
+  --bg3: #000000;
+  --bg4: #000000;
+}
+
+body[data-theme="light"] {
+  --accent: #2c5364;
+  --text-color: #000000;
+  --bg1: #ffffff;
+  --bg2: #f0f0f0;
+  --bg3: #ffffff;
+  --bg4: #f0f0f0;
+}
+
 body {
   font-family: "Helvetica Neue", Arial, sans-serif;
-   background-color: #2a2f3b;
-  color: #f8f8f4;
+  color: var(--text-color);
   display: flex;
   flex-direction: column;
   align-items: center;
   padding-top: 2em;
+  background: linear-gradient(-45deg, var(--bg1), var(--bg2), var(--bg3), var(--bg4));
+  background-size: 400% 400%;
+  animation: gradientBG 15s ease infinite;
+  min-height: 100vh;
 }
 
-h1 {
-  font-weight: 300;
-  letter-spacing: 2px;
+@keyframes gradientBG {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+/* Title */
+.title {
+  font-family: "Orbitron", sans-serif;
+  color: var(--accent);
+  text-shadow: 0 0 8px var(--accent), 0 0 16px var(--accent);
+  animation: flicker 3s infinite;
   margin-bottom: 0.5em;
 }
 
-.select {
-  border-radius: 5px;
-  padding: 5px;
+@keyframes flicker {
+  0%, 19%, 21%, 23%, 25%, 54%, 56%, 100% {
+    opacity: 1;
+  }
+  20%, 24%, 55% {
+    opacity: 0.4;
+  }
 }
 
-.selected {
-  background-color: #2a2f3b;
-  padding: 5px;
-  margin-bottom: 3px;
-  border-radius: 5px;
-  position: relative;
-  z-index: 100000;
-  font-size: 15px;
+/* Theme toggle */
+.theme-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  background: transparent;
+  border: 2px solid var(--accent);
+  color: var(--accent);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  cursor: pointer;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
+  transition: all 0.3s ease-in-out;
 }
 
-.options {
-  display: flex;
-  flex-direction: column;
-  border-radius: 5px;
-  padding: 5px;
-  background-color: #2a2f3b;
+.theme-toggle:hover {
+  background-color: var(--accent);
+  color: #000;
+  box-shadow: 0 0 10px var(--accent), 0 0 20px var(--accent);
+}
+
+/* Difficulty dropdown */
+.dropdown {
   position: relative;
-  top: -100px;
-  opacity: 0;
-  transition: 300ms;
-  color: white;
+  width: 200px;
+  cursor: pointer;
 }
 
-.select:hover > .options {
-  opacity: 1;
-  top: 0;
+.dropdown .selected {
+  border: 2px solid var(--accent);
+  padding: 10px;
+  border-radius: 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.2);
 }
 
-.select:hover > .selected .arrow {
-  transform: rotate(0deg);
+.dropdown .options {
+  position: absolute;
+  top: 110%;
+  left: 0;
+  width: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 12px;
+  display: none;
+  flex-direction: column;
+  z-index: 10;
 }
 
-.option {
-  border-radius: 5px;
-  padding: 5px;
-  transition: 300ms;
-  background-color: #2a2f3b;
-  width: 150px;
-  font-size: 15px;
-  color: white;
+.dropdown.open .options {
+  display: flex;
+  animation: fadeIn 0.3s ease forwards;
 }
 
-.option:hover {
-  background-color: #323741;
+.dropdown .option {
+  padding: 10px;
+  border-radius: 8px;
+  transition: background 0.3s;
+  color: var(--text-color);
 }
 
+.dropdown .option:hover {
+  background-color: rgba(0, 255, 231, 0.1);
+}
+
+/* Button */
+.button {
+  border: 2px solid var(--accent);
+  color: var(--accent);
+  background-color: transparent;
+  padding: 10px 20px;
+  border-radius: 12px;
+  font-weight: bold;
+  text-transform: uppercase;
+  transition: all 0.3s ease-in-out;
+  margin-top: 1em;
+}
+
+.button:hover {
+  background-color: var(--accent);
+  color: #000;
+  box-shadow: 0 0 10px var(--accent), 0 0 20px var(--accent);
+  transform: scale(1.05);
+}
+
+/* Sudoku grid */
 table {
   border-collapse: collapse;
   margin-top: 1em;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
 }
 
 td {
@@ -80,6 +172,7 @@ td {
   border: 1px solid #888;
   font-size: 20px;
   background-color: #f8f8f4;
+  transition: background-color 0.3s;
 }
 
 tr:nth-child(3n) td {
@@ -95,3 +188,54 @@ td.given {
   color: #b2985a;
   background: #f2f0eb;
 }
+
+td.cell:hover {
+  background-color: rgba(0, 255, 231, 0.1);
+  box-shadow: inset 0 0 8px var(--accent);
+}
+
+td.highlight {
+  background-color: rgba(0, 255, 231, 0.2);
+}
+
+.fade-in {
+  animation: fadeIn 0.5s ease forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: scale(0.8);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: #1a1a2e;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 0 10px var(--accent);
+  text-align: center;
+}
+

--- a/webapp/sudoku.js
+++ b/webapp/sudoku.js
@@ -189,6 +189,7 @@ window.addEventListener("DOMContentLoaded", () => {
     dropdown.classList.toggle("open");
   });
   options.addEventListener("click", (e) => {
+    e.stopPropagation();
     const option = e.target.closest(".option");
     if (!option) return;
     currentDifficulty = option.dataset.value;

--- a/webapp/sudoku.js
+++ b/webapp/sudoku.js
@@ -116,29 +116,103 @@ const generatePuzzle = (difficulty) => {
   return puzzle;
 };
 
+let currentDifficulty = "easy";
+
 const render = (grid) => {
   const table = document.getElementById("grid");
   table.innerHTML = "";
-  for (const row of grid) {
+  grid.forEach((row, rIdx) => {
     const tr = document.createElement("tr");
-    for (const val of row) {
+    row.forEach((val, cIdx) => {
       const td = document.createElement("td");
-      if (val !== 0) {
-        td.textContent = val;
-        td.classList.add("given");
-      } else {
-        td.textContent = "";
-      }
+      td.classList.add("cell");
+      td.dataset.row = rIdx;
+      td.dataset.col = cIdx;
+      setTimeout(() => {
+        if (val !== 0) {
+          td.textContent = val;
+          td.classList.add("given");
+        } else {
+          td.textContent = "";
+        }
+        td.classList.add("fade-in");
+      }, (rIdx * 9 + cIdx) * 30);
+      td.addEventListener("click", () => highlight(rIdx, cIdx));
       tr.appendChild(td);
-    }
+    });
     table.appendChild(tr);
+  });
+};
+
+const highlighted = [];
+const clearHighlight = () => {
+  while (highlighted.length) {
+    highlighted.pop().classList.remove("highlight");
   }
 };
 
+const highlight = (row, col) => {
+  clearHighlight();
+  document.querySelectorAll("td.cell").forEach((cell) => {
+    const r = Number(cell.dataset.row);
+    const c = Number(cell.dataset.col);
+    if (
+      r === row ||
+      c === col ||
+      (Math.floor(r / 3) === Math.floor(row / 3) &&
+        Math.floor(c / 3) === Math.floor(col / 3))
+    ) {
+      cell.classList.add("highlight");
+      highlighted.push(cell);
+    }
+  });
+};
+
+const showModal = () => {
+  document.getElementById("modal").classList.remove("hidden");
+};
+
+const closeModal = () => {
+  document.getElementById("modal").classList.add("hidden");
+};
+
+const generateAndRender = () => {
+  const grid = generatePuzzle(currentDifficulty);
+  render(grid);
+};
+
 window.addEventListener("DOMContentLoaded", () => {
-  document.getElementById("generate").addEventListener("click", () => {
-    const difficulty = document.getElementById("difficulty").value;
-    const grid = generatePuzzle(difficulty);
-    render(grid);
+  const dropdown = document.getElementById("difficulty");
+  const selected = dropdown.querySelector(".selected");
+  const options = dropdown.querySelector(".options");
+  dropdown.addEventListener("click", () => {
+    dropdown.classList.toggle("open");
+  });
+  options.addEventListener("click", (e) => {
+    const option = e.target.closest(".option");
+    if (!option) return;
+    currentDifficulty = option.dataset.value;
+    selected.textContent = option.textContent;
+    dropdown.classList.remove("open");
+    if (currentDifficulty === "korean") {
+      showModal();
+    }
+  });
+  document.getElementById("close-modal").addEventListener("click", closeModal);
+
+  document.getElementById("generate").addEventListener("click", generateAndRender);
+
+  const themes = ["neon", "retro", "light"];
+  let themeIndex = 0;
+  document.getElementById("theme-toggle").addEventListener("click", () => {
+    themeIndex = (themeIndex + 1) % themes.length;
+    document.body.setAttribute("data-theme", themes[themeIndex]);
+  });
+
+  window.addEventListener("keydown", (e) => {
+    if (e.ctrlKey && e.key.toLowerCase() === "g") {
+      e.preventDefault();
+      generateAndRender();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Revamp HTML structure with custom difficulty dropdown, theme toggle, and modal warning for expert mode
- Introduce animated gradient background, neon title, holographic button, and fade-in cell/row highlights
- Add theme switching and keyboard shortcut support in Sudoku renderer

## Testing
- `npm test` *(fails: Could not read package.json)*
- `javac -cp src tests/com/company/*.java` *(fails: package org.junit.jupiter.api does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688e4f63c96083249874e08cc2f0f046